### PR TITLE
HOCS-2367: consolidate version param

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -134,7 +134,7 @@ steps:
         --registryUser=ukhomeofficedigital+hocs_quay_robot
         --service=hocs-docs-converter
         --serviceGitToken=$${GITHUB_TOKEN}
-        --sourceBuild=$${IMAGE_VERSION}
+        --sourceBuild=$${VERSION}
         --version=$${SEMVER}
         --versionRepo="https://gitlab.digital.homeoffice.gov.uk/hocs/hocs-versions.git"
         --versionRepoServiceToken=$${GITLAB_TOKEN}


### PR DESCRIPTION
Currently we have 2 interchangeable parameters for the version, 
`VERSION` and `IMAGE_VERSION`. This change consolidates this 
so only one is now used `VERSION`