### PR TITLE
Fix/hocs 2637 refactor drone script

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,14 @@ steps:
   - name: build project
     image: quay.io/ukhomeofficedigital/hocs-libreoffice:build-35
     commands:
-      - ./gradlew build
+      - ./gradlew assemble --no-daemon
+
+  - name: test project
+    image: quay.io/ukhomeofficedigital/hocs-libreoffice
+    commands:
+      - ./gradlew check --no-daemon
+    depends_on:
+      - build project
 
   - name: build & push
     image: plugins/docker
@@ -23,7 +30,7 @@ steps:
         from_secret: QUAY_ROBOT_TOKEN
       DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
     depends_on:
-      - build project
+      - test project
 
   - name: build & push latest
     image: plugins/docker
@@ -40,7 +47,7 @@ steps:
       branch:
         - main
     depends_on:
-      - build project
+      - test project
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: build
 
 steps:
   - name: build project
-    image: quay.io/ukhomeofficedigital/hocs-libreoffice:build-35
+    image: quay.io/ukhomeofficedigital/hocs-libreoffice
     commands:
       - ./gradlew assemble --no-daemon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM quay.io/ukhomeofficedigital/hocs-libreoffice:build-35
-
+FROM quay.io/ukhomeofficedigital/hocs-libreoffice
 ENV TZ Europe/London
 ENV LANGUAGE en_GB.UTF-8
 ENV LANG en_GB.UTF-8


### PR DESCRIPTION
Currently we have a build step that not only builds but also tests the 
project. This change splits this step into a `build project` step and a 
`test project` step for better visibility incase the pipeline fails.

Currently we use a static version of `hocs-libreoffice` of `build-35`. This 
means that any changes and potentially improvements that we make to 
that repository will not be reflected in hocs-docs-converter. This change 
ensures that we use the latest build of hocs-libreoffice for our builds.