### PR TITLE
HOCS-3507 upgrade the image to an alpine based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,19 @@
 FROM quay.io/ukhomeofficedigital/hocs-libreoffice
-ENV TZ Europe/London
-ENV LANGUAGE en_GB.UTF-8
-ENV LANG en_GB.UTF-8
-ENV LC_ALL en_GB.UTF-8
 
-ENV USER user_hocs_docs
+ENV USER user_hocs_docs_converter
 ENV USER_ID 1000
-ENV GROUP group_hocs_docs
+ENV GROUP group_hocs_docs_converter
 ENV NAME hocs-docs-converter
 ENV JAR_PATH build/libs
 
-RUN yum update -y glibc && \
-    yum update -y nss && \
-    yum update -y bind-license
+USER root
+
+RUN apk add --no-cache openjdk11-jre
 
 WORKDIR /app
 
-RUN groupadd -r ${GROUP} && \
-    useradd -r -u ${USER_ID} -g ${GROUP} ${USER} -d /app && \
+RUN addgroup -S ${GROUP} && \
+    adduser -S -u ${USER_ID} ${USER} -G ${GROUP} -h /app && \
     mkdir -p /app && \
     chown -R ${USER}:${GROUP} /app
 
@@ -31,4 +27,4 @@ EXPOSE 8080
 
 USER ${USER_ID}
 
-CMD /app/scripts/run.sh
+CMD ["sh", "/app/scripts/run.sh"]

--- a/app/scripts/run.sh
+++ b/app/scripts/run.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-NAME=${NAME:-hocs-docs-converter}
-
-JAR=$(find . -name ${NAME}*.jar|head -1)
-java ${JAVA_OPTS} -Dcom.sun.management.jmxremote.local.only=false -Djava.security.egd=file:/dev/./urandom -jar "${JAR}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,4 +3,4 @@
 NAME=${NAME:-docs}
 
 JAR=$(find . -name ${NAME}*.jar|head -1)
-exec /usr/local/java/bin/java ${JAVA_OPTS} -Dcom.sun.management.jmxremote.local.only=false -Djava.security.egd=file:/dev/./urandom -jar "${JAR}"
+exec java ${JAVA_OPTS} -Dcom.sun.management.jmxremote.local.only=false -Djava.security.egd=file:/dev/./urandom -jar "${JAR}"


### PR DESCRIPTION
This commit upgrades the image to an alpine based image with a single installed version of Libreoffice. The old base image installed Libreoffice twice and didn't clean up after itself.