### PR TITLE
Add a wildcard for dependabot

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ steps:
       branch:
         exlude:
           - main
-          - dependabot
+          - "dependabot*"
     depends_on:
       - test project
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
       directory: "/"
       schedule:
           interval: "daily"
+      pull-request-branch-name:
+        separator: "-"


### PR DESCRIPTION
Add a wildcard for dependabot and change the branch separator from the default ''/' to '-'