### PR TITLE
HOCS-4808: produce tagged builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -125,8 +125,6 @@ name: build tag
 trigger:
   event:
     - tag
-  branch:
-    - main
 
 steps:
   - name: test project
@@ -134,7 +132,7 @@ steps:
     commands:
       - ./gradlew clean build --no-daemon
 
-  - name: build & push
+  - name: build & push tag main
     image: plugins/docker
     settings:
       registry: quay.io
@@ -149,6 +147,28 @@ steps:
       DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
     depends_on:
       - test project
+    when:
+      branch:
+        - main
+
+  - name: build & push tag
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-docs-converter
+      tags:
+        - ${DRONE_TAG}
+        - ${DRONE_COMMIT_SHA}
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    depends_on:
+      - test project
+    when:
+      branch:
+        exclude:
+          - main
 
 ---
 kind: pipeline


### PR DESCRIPTION
On tag of non-mainline branch create a Quay image that can be used for
hotfixing environments.