### PR TITLE
HOCS-5639: install MS fonts into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && \
     apt-get install -y software-properties-common && \
     add-apt-repository ppa:libreoffice/ppa && \
     apt-get install libreoffice --no-install-recommends  --no-install-suggests -y && \
+    echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections && \
+    apt-get install -y ttf-mscorefonts-installer && \
     apt-get clean
 
 WORKDIR /app


### PR DESCRIPTION
Installation of MS proprietary fonts i.e. Arial for use within the converter to mimic user behaviour and give a representative experience.

`fc-match Arial` returns `Arial.ttf: "Arial" "Regular"` as expected

As the package has a Microsoft EULA, we accept that as well.